### PR TITLE
Add temporary frame deletion

### DIFF
--- a/utils/swap_func.py
+++ b/utils/swap_func.py
@@ -169,3 +169,5 @@ def video_swap(opt, face, input_video, RetinaFace, ArcFace, FaceDancer, out_vide
             sys.exit(0)
 
         print('\nDone! {}'.format(out_video_filename))
+        # Delete temporary frames after completion
+        shutil.rmtree(temp_results_dir)


### PR DESCRIPTION
I realized the temporary frames weren't deleting after completion so I added a single line that deletes the tmp_frames directory right after it finishes. 
This directory sometimes takes GBs of place so I thought this would be useful.

Thank you for this nice project.