### PR TITLE
Fix "width not divisible by 2" error

### DIFF
--- a/utils/swap_func.py
+++ b/utils/swap_func.py
@@ -159,8 +159,10 @@ def video_swap(opt, face, input_video, RetinaFace, ArcFace, FaceDancer, out_vide
             sys.exit(0)
     else:
         try:
+            # .h264 needs even dimensions so added filter will do the steps mentioned in the following link
+            # https://stackoverflow.com/a/20848224/9969425
             clips.write_videofile(out_video_filename, codec='libx264', audio_codec='aac', ffmpeg_params=[
-                '-pix_fmt:v', 'yuv420p', '-colorspace:v', 'bt709', '-color_primaries:v', 'bt709',
+                '-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2', '-pix_fmt:v', 'yuv420p', '-colorspace:v', 'bt709', '-color_primaries:v', 'bt709',
                 '-color_trc:v', 'bt709', '-color_range:v', 'tv', '-movflags', '+faststart'],
                                   logger=proglog.TqdmProgressBarLogger(print_messages=False))
         except Exception as e:


### PR DESCRIPTION
I had the following error a few times while using this
```
ERROR! Failed to export video

 [Errno 22] Invalid argument

MoviePy error: FFMPEG encountered the following error while writing file results/swapped_video8.mp4:

 b'[libx264 @ 000001f26be1dd80] width not divisible by 2 (931x500)\r\nError initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height\r\n'
```
So I added a small filter that will:
1. Divide the original height and width by 2
2. Round it up to the nearest pixel
3. Multiply it by 2 again, thus making it an even number
4. Add black padding pixels up to this number

I used the the following stackoverflow answer to fix this
https://stackoverflow.com/a/20848224/9969425